### PR TITLE
Pass Retry-After header through on errors

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -47,7 +47,7 @@ func TestClient_getRetryAfter(t *testing.T) {
 		resp := http.Response{Header: http.Header{"Retry-After": []string{tc.retryHeader}}}
 		result := getRetryAfter(&resp)
 		if result != tc.expResult {
-			t.Error("Expected %d, got %d on test case %d", tc.expResult, result, i)
+			t.Errorf("Expected %d, got %d on test case %d", tc.expResult, result, i)
 		}
 	}
 }

--- a/client_test.go
+++ b/client_test.go
@@ -19,3 +19,35 @@ func TestClient_doReq(t *testing.T) {
 		t.Fatalf("se.StatusCode. got %d, want %d", se.StatusCode, http.StatusNotFound)
 	}
 }
+
+func TestClient_getRetryAfter(t *testing.T) {
+	testCases := []struct {
+		retryHeader string
+		expResult   int
+	}{
+		{
+			retryHeader: "",
+			expResult:   0,
+		},
+		{
+			retryHeader: "unparseable",
+			expResult:   0,
+		},
+		{
+			retryHeader: "15",
+			expResult:   15,
+		},
+		{
+			retryHeader: "60",
+			expResult:   60,
+		},
+	}
+
+	for i, tc := range testCases {
+		resp := http.Response{Header: http.Header{"Retry-After": []string{tc.retryHeader}}}
+		result := getRetryAfter(&resp)
+		if result != tc.expResult {
+			t.Error("Expected %d, got %d on test case %d", tc.expResult, result, i)
+		}
+	}
+}

--- a/fullstory_test.go
+++ b/fullstory_test.go
@@ -3,6 +3,7 @@ package fullstory
 import (
 	"compress/gzip"
 	"io/ioutil"
+	"net/http"
 	"testing"
 	"time"
 )
@@ -97,5 +98,26 @@ func TestExportDataGzip(t *testing.T) {
 	expect := `{"foo":bar, "hello:world", "answer":42, "question":null}`
 	if s != expect {
 		t.Fatalf("got %q, want %q", s, expect)
+	}
+}
+
+func TestExportDataRetry(t *testing.T) {
+	t.Parallel()
+	_, err := client2.ExportData(11111)
+	if err == nil {
+		t.Fatal("Expected to be throttled, but got success!")
+	}
+
+	statusError, ok := err.(StatusError)
+	if !ok {
+		t.Fatalf("did not get a StatusError")
+	}
+
+	if statusError.StatusCode != http.StatusTooManyRequests {
+		t.Fatalf("got %d, want %d for StatusCode", statusError.StatusCode, http.StatusTooManyRequests)
+	}
+
+	if statusError.RetryAfter != retryAfter {
+		t.Fatalf(" got %d, want %d for RetryAfter", statusError.RetryAfter, retryAfter)
 	}
 }

--- a/fullstory_test.go
+++ b/fullstory_test.go
@@ -117,7 +117,8 @@ func TestExportDataRetry(t *testing.T) {
 		t.Fatalf("got %d, want %d for StatusCode", statusError.StatusCode, http.StatusTooManyRequests)
 	}
 
-	if statusError.RetryAfter != retryAfter {
-		t.Fatalf(" got %d, want %d for RetryAfter", statusError.RetryAfter, retryAfter)
+	expRetryAfter := time.Duration(retryAfter) * time.Second
+	if statusError.RetryAfter != expRetryAfter {
+		t.Fatalf("got %v, want %v for RetryAfter", statusError.RetryAfter, expRetryAfter)
 	}
 }


### PR DESCRIPTION
This library is used by the [hauser](https://github.com/fullstorydev/hauser) utility.  We would like to improve hauser's handling of 429 responses from FullStory servers, i.e. wait for at least the time designated in the Retry-After header (if we're naively assuming there are no other clients consuming tokens). However, this the Retry-After header is not currently returned by this client when an error occurs.

We made a quick and dirty change to get hold of the header in [hauser PR #26](https://github.com/fullstorydev/hauser/pull/26), but this PR ports those changes back to this library properly.