### PR TITLE
fix BaseURL

### DIFF
--- a/client.go
+++ b/client.go
@@ -10,7 +10,7 @@ import (
 )
 
 // BaseURL is the base URL for the fullstory.com API.
-const BaseURL = "https://export.fullstory.com/api/v1"
+const BaseURL = "https://fullstory.com/api/v1"
 
 var _ error = StatusError{}
 


### PR DESCRIPTION
If old URL `https://fullstory.com/api/v1` will work for all of the client methods `Sessions`, `ExportData`, and `ExportList`, we can switch it back to the old one now to fix—as this PR does. If it won't, I can reformulate this PR to introduce the correct, separate URLs for each client method.

More discussion: https://github.com/nishanths/fullstory/commit/272735d360883d9fb41d542b464bc6cdc4f517ee#r32661854